### PR TITLE
tweak UA override to handle "find other sizes" and "visually similar images" as well

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -75,7 +75,9 @@ function startup(aData, aReason) {
     We need to provide the Chrome User Agent for these urls
   */
   UserAgentOverrides.addComplexOverride(function googleImageSearchUserAgentOverride(channel, DEFAULT_UA){
-    if (channel.URI.host.indexOf("google.") !== -1 && (channel.URI.path.startsWith("/searchbyimage?") || channel.URI.path.startsWith("/search?tbs=sbi:"))){
+    if (channel.URI.host.indexOf("google.") !== -1 && (channel.URI.path.startsWith("/searchbyimage?") ||
+                                                       channel.URI.path.startsWith("/search?tbs=sbi:") ||
+                                                       channel.URI.path.contains("tbs=simg:"))){
       return CHROME_USER_AGENT;
     }
   });


### PR DESCRIPTION
It's not perfect, but otherwise you'd probably end up having to override the user agent on most of Google's pages.
